### PR TITLE
Ensure that unicode characters - even accidental are encoded

### DIFF
--- a/plugins/cck_field/field_x/field_x.php
+++ b/plugins/cck_field/field_x/field_x.php
@@ -371,7 +371,7 @@ class plgCCK_FieldField_X extends JCckPluginField
 		$html	=	'<div>';
 		$html	.=	'<div id="collection-group-wrap-'.$field->name.'__'.$i.'" class="collection-group-wrap">';
 		$html	.=	'<div id="collection-group-form-'.$field->name.'__'.$i.'" class="collection-group-form">';
-		$html	.=	$elem->form;
+		$html	.=	mb_convert_encoding($elem->form, 'HTML-ENTITIES');
 		$html	.=	'</div>';
 		$html	.=	'<div id="collection-group-button-'.$field->name.'__'.$i.'" class="collection-group-button">';
 		if ( $field->bool3 ) {


### PR DESCRIPTION
I have found this problem when one of users saved unicode E280A8 as part of an article title and this title was pulled into a field_x via a SQL based select field. Same fix probably required for group_x
